### PR TITLE
Compatibility with dplyr 1.1.0

### DIFF
--- a/R/FRK.R
+++ b/R/FRK.R
@@ -42,3 +42,9 @@
 #' @importFrom ggpubr ggarrange
 #' @importFrom reshape2 melt
 NULL
+
+# With data frames, returns last column whereas `dplyr::last()`
+# returns last row
+last2 <- function(x) {
+  x[[length(x)]]
+}

--- a/R/geometryfns.R
+++ b/R/geometryfns.R
@@ -1257,7 +1257,7 @@ setMethod("map_data_to_BAUs",signature(data_sp="SpatialPoints"),
                 
                 ## Sum specified columns; if(is.null(sum_variables)), 
                 ## then tmp1 will just be the BAU_name column (which will be dropped once we merge afterwards). 
-                tmp2 <- select(data_over_sp, c(sum_variables, BAU_name)) %>% # Need BAU_name in order to summarise by group; BAU_name is a string, so safe.sum() will just return the first element
+                tmp2 <- select(data_over_sp, all_of(sum_variables), BAU_name) %>% # Need BAU_name in order to summarise by group; BAU_name is a string, so safe.sum() will just return the first element
                   group_by(BAU_name) %>%                       # group by BAU
                   summarise_all(.safe_sum) %>%                 # apply safe mean to each column BAU
                   as.data.frame()                              # convert to data frame 

--- a/R/geometryfns.R
+++ b/R/geometryfns.R
@@ -1419,14 +1419,14 @@ setMethod("map_data_to_BAUs",signature(data_sp="ST"),
                                   t1 <- time(sp_pols)[i]
                                   
                                   ## If this is not the last (initial) time point
-                                  if(i < last(sp_pols@time)) {
+                                  if(i < last2(sp_pols@time)) {
                                     ## Then mark the beginning of the next time interval as the end of this one
                                     t2 <- time(sp_pols)[i+1]
                                     
                                   } else {
                                     
                                     ## If we are the last time interval then lump all data into this interval
-                                    t2 <- last(data_sp@endTime) + 1
+                                    t2 <- last2(data_sp@endTime) + 1
                                   }
                                   
                                   ## Now we know which data to bin in space, those appearing between t1 and t2


### PR DESCRIPTION
- Use `all_of()` with external variables to silence a warning
- Use `[[` to subset last column instead of `dplyr::last()`. The latter now retrieves the last row instead of the last column.

We plan to release on January 27. These changes are compatible with both CRAN and dev dplyr. A pre-emptive release would be helpful if possible. Thanks!